### PR TITLE
chore: pnpm prisma generate

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,5 +15,4 @@ README.md
 build
 public/build
 data
-
-
+prisma/prisma-client

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ yarn-error.log*
 /.cache
 /public/build
 data
+prisma/prisma-client

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,23 +35,19 @@ FROM base as build
 WORKDIR /app
 
 COPY --from=deps /app/node_modules /app/node_modules
-COPY package.json pnpm-lock.yaml ./
-RUN pnpm install --offline --frozen-lockfile
-
-COPY prisma .
-RUN pnpm exec prisma generate
-
 COPY . .
-RUN pnpm run build
-
+RUN pnpm install --offline --frozen-lockfile \
+  && pnpm exec prisma generate \
+  && pnpm run build
 
 # Run the app
 FROM base
 
+ENV NODE_ENV "production"
 WORKDIR /app
 
 COPY --from=production-deps /app/package.json /app/package.json
-COPY --from=build /app/node_modules /app/node_modules
+COPY --from=production-deps /app/node_modules /app/node_modules
 COPY --from=build /app/tsconfig.json /app/tsconfig.json
 COPY --from=build /app/prisma /app/prisma
 COPY --from=build /app/build /app/build

--- a/app/components/EventCard.tsx
+++ b/app/components/EventCard.tsx
@@ -16,9 +16,9 @@ import {
   Text,
   type CardProps,
 } from '@chakra-ui/react'
-import type { LumaEvent } from '@prisma/client'
 import { Link as RemixLink, useNavigate } from '@remix-run/react'
 import { RiMapPinLine, RiTeamLine } from 'react-icons/ri'
+import type { LumaEvent } from '~/services/database.server'
 import dayjs from '~/utils/dayjs'
 import { AppLinkButton } from './AppLinkButton'
 

--- a/app/jobs/cluster-event-guests.server.ts
+++ b/app/jobs/cluster-event-guests.server.ts
@@ -1,6 +1,5 @@
-import { Prisma } from '@prisma/client'
 import kmeans from 'skmeans'
-import { prisma } from '~/services/database.server'
+import { prisma, Prisma } from '~/services/database.server'
 import { lru } from '~/services/lru-cache.server'
 
 export const clusterEventGuests = async (eventId: string, clusterNum = 3) => {

--- a/app/models/demo-track-presenter.server.ts
+++ b/app/models/demo-track-presenter.server.ts
@@ -1,5 +1,4 @@
-import type { DemoTrack } from '@prisma/client'
-import { prisma } from '~/services/database.server'
+import { prisma, type DemoTrack } from '~/services/database.server'
 import { convertEventGuest } from './luma-event-guest.server'
 
 export const listDemoTrackPresenters = async (trackId: DemoTrack['id']) => {

--- a/app/models/demo-track.server.ts
+++ b/app/models/demo-track.server.ts
@@ -1,10 +1,10 @@
+import { cachified } from 'cachified'
 import type {
   DemoTrack,
   LumaEvent,
   LumaEventGuest,
   Prisma,
-} from '@prisma/client'
-import { cachified } from 'cachified'
+} from '~/services/database.server'
 import { prisma } from '~/services/database.server'
 import { lru } from '~/services/lru-cache.server'
 import { convertEventGuest } from './luma-event-guest.server'

--- a/app/models/luma-crawl-job.server.ts
+++ b/app/models/luma-crawl-job.server.ts
@@ -1,5 +1,8 @@
-import { type LumaCrawlState, type LumaEvent } from '@prisma/client'
-import { prisma } from '~/services/database.server'
+import {
+  prisma,
+  type LumaCrawlState,
+  type LumaEvent,
+} from '~/services/database.server'
 
 /**
  * Luma クロールジョブが実行中かどうか

--- a/app/models/luma-event-guest.server.ts
+++ b/app/models/luma-event-guest.server.ts
@@ -1,5 +1,9 @@
-import type { LumaEventGuest, LumaUser, Prisma } from '@prisma/client'
 import { cachified } from 'cachified'
+import type {
+  LumaEventGuest,
+  LumaUser,
+  Prisma,
+} from '~/services/database.server'
 import { prisma } from '~/services/database.server'
 import { lru } from '~/services/lru-cache.server'
 import { type LumaApiGuest } from '~/services/luma.server'

--- a/app/models/luma-event.server.ts
+++ b/app/models/luma-event.server.ts
@@ -1,6 +1,5 @@
-import type { LumaEvent, Prisma } from '@prisma/client'
 import { cachified } from 'cachified'
-import { prisma } from '~/services/database.server'
+import { prisma, type LumaEvent, type Prisma } from '~/services/database.server'
 import { lru } from '~/services/lru-cache.server'
 
 export const listLumaEvents = async () => {

--- a/app/routes/_app+/event.$eventId.track.$trackId.tsx
+++ b/app/routes/_app+/event.$eventId.track.$trackId.tsx
@@ -8,7 +8,6 @@ import {
   Stack,
   Text,
 } from '@chakra-ui/react'
-import type { DemoTrack } from '@prisma/client'
 import type { LoaderArgs } from '@remix-run/node'
 import { Outlet, Link as RemixLink, useNavigate } from '@remix-run/react'
 import { GiPlayerNext } from 'react-icons/gi'
@@ -19,6 +18,7 @@ import { zx } from 'zodix'
 import { DemoTrackCard } from '~/components/DemoTrackCard'
 import { EventGuestItem } from '~/components/EventGuestItem'
 import { getEventDemoTrack, listDemoTrackPresenters } from '~/models'
+import type { DemoTrack } from '~/services/database.server'
 
 export const handle = {
   breadcrumb: ({

--- a/app/routes/_app+/event.$eventId.tsx
+++ b/app/routes/_app+/event.$eventId.tsx
@@ -1,5 +1,4 @@
 import { Stack } from '@chakra-ui/react'
-import type { LumaEvent } from '@prisma/client'
 import { type LoaderArgs } from '@remix-run/node'
 import { Outlet } from '@remix-run/react'
 import { typedjson, useTypedLoaderData } from 'remix-typedjson'
@@ -7,6 +6,7 @@ import { z } from 'zod'
 import { zx } from 'zodix'
 import { EventCard } from '~/components/EventCard'
 import { getEventById } from '~/models'
+import type { LumaEvent } from '~/services/database.server'
 
 export const handle = {
   breadcrumb: ({ event }: { event: LumaEvent }) => ({

--- a/app/services/database.server.ts
+++ b/app/services/database.server.ts
@@ -1,4 +1,5 @@
-import { PrismaClient } from '@prisma/client'
+import { PrismaClient } from '../../prisma/prisma-client'
+export * from '../../prisma/prisma-client'
 
 export const prisma = new PrismaClient({
   log:

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3,6 +3,7 @@
 
 generator client {
   provider = "prisma-client-js"
+  output = "./prisma-client"
 }
 
 datasource db {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,6 +1,4 @@
-import { PrismaClient } from '@prisma/client'
-
-const prisma = new PrismaClient()
+import { prisma } from '~/services/database.server'
 
 async function seed() {
   await prisma.user.deleteMany({})


### PR DESCRIPTION
Dockerfile のチューニングで、
pnpm 経由で prisma generate すると生成される先が node_modules 下の不定なパスになるので、
prisma client 側で場所を固定、それに合わせて各種辻褄合わせをしました。

最終的には devDependencies の node_modules をプロダクションイメージから除外されるだけです。